### PR TITLE
Automatically make some essential files

### DIFF
--- a/mw.py
+++ b/mw.py
@@ -7,6 +7,11 @@ class MemoryWatcher:
     def __init__(self, path):
         """Creates the socket if it does not exist, and then opens it."""
         try:
+            # if necessary, create the parent directory
+            os.mkdir(path[:path.rfind('/')])
+        except OSError:
+            pass
+        try:
             os.unlink(path)
         except OSError:
             pass

--- a/p3.py
+++ b/p3.py
@@ -5,6 +5,7 @@ import pad
 import addr
 import controller
 import sys
+import os
 
 if __name__ == '__main__':
     if len(sys.argv) != 2:
@@ -13,6 +14,11 @@ if __name__ == '__main__':
 
     pad = pad.Pad(home + '/Pipes/p3')
     mw = mw.MemoryWatcher(home + '/MemoryWatcher/MemoryWatcher')
+
+    # if necessary, create Locations.txt based on addr.locationsTxt
+    if not os.path.exists(home + '/MemoryWatcher/Locations.txt'):
+        with open(home + '/MemoryWatcher/Locations.txt', 'w') as file:
+            file.write(addr.locationsTxt)
 
     currentFrame = 0;
     controller1 = controller.Controller();

--- a/p3.py
+++ b/p3.py
@@ -12,6 +12,9 @@ if __name__ == '__main__':
         sys.exit('Usage: ' + sys.argv[0] + ' dolphin-home')
     home = sys.argv[1]
 
+    if not os.path.exists(home):
+        sys.exit('The path \'' + home + '\' does not exist')
+
     pad = pad.Pad(home + '/Pipes/p3')
     mw = mw.MemoryWatcher(home + '/MemoryWatcher/MemoryWatcher')
 

--- a/pad.py
+++ b/pad.py
@@ -31,6 +31,11 @@ class Pad:
     def __init__(self, path):
         """Opens the fifo. Blocks until the other end is listening."""
         try:
+            # if necessary, create the parent directory
+            os.mkdir(path[:path.rfind('/')])
+        except OSError:
+            pass
+        try:
             os.mkfifo(path)
         except OSError:
             pass


### PR DESCRIPTION
These changes perform a sanity check on the home directory arg and automatically create (as needed) the fifo pipe, the MemoryWatcher socket, `Locations.txt`, and the directories that contain each.  Hopefully this will make running `p3.py` a bit more convenient :smile:

It would be neat if the program could also do things like ensure that the home directory was a proper dolphin-emu directory and copy `pipe.ini` to the appropriate config folder, but since those locations are more variable, it's probably better at this stage to handle those types of concerns with documentation.
